### PR TITLE
Implement way to proove ownership of server before attempting rcon authenticating

### DIFF
--- a/graphql-server/defs.ts
+++ b/graphql-server/defs.ts
@@ -2,3 +2,14 @@ export interface ServerArguments {
   host: string
   password: string
 };
+
+export interface TokenData {
+  password: string
+  secret: string
+  host: string
+};
+
+export interface CreateTokenArguments {
+  password: string
+  host: string
+};

--- a/graphql-server/index.ts
+++ b/graphql-server/index.ts
@@ -1,6 +1,7 @@
 import { ApolloServer, gql } from 'apollo-server';
-import { SourceServer } from '../../steam-condenser-js';
-import { ServerArguments } from './defs';
+import { SourceServer } from 'steam-condenser';
+import { ServerArguments, CreateTokenArguments } from './defs';
+import { createToken } from './token';
 
 const TIMEOUT = 1000;
 
@@ -74,16 +75,29 @@ const typeDefs = gql`
     v: String!
   }
 
+  type Token {
+    token: String!
+  }
+
   # The "Query" type is special: it lists all of the available queries that
   # clients can execute, along with the return type for each. In this
   # case, the "books" query returns an array of zero or more Books (defined above).
   type Query {
     server(host: String!, password: String): SourceServer
+    createToken(password: String!, host: String!): Token
   }
 `;
 
 const resolvers = {
   Query: {
+    createToken: async (_: any, { password, host }: CreateTokenArguments) => {
+      const token = await createToken({
+        password,
+        host,
+        secret: RCON_PROOF_SECRET
+      });
+      return { token: RCON_PROOF_PREFIX + token };
+    },
     server: async (_: any, { host, password }: ServerArguments) => {
       console.log(host)
       const server = new SourceServer(host);

--- a/graphql-server/index.ts
+++ b/graphql-server/index.ts
@@ -107,14 +107,17 @@ const resolvers = {
         if (RCON_PROOF_REQUIRED) {
           const rules = await server.getRules();
           let tag: string | undefined;
-          if (rules['tags'] && (tag = rules['tags'].split(',').find((tag) => tag.startsWith(RCON_PROOF_PREFIX)))) {
+          if (rules['sv_tags'] && (tag = rules['sv_tags'].split(',').find((tag) => tag.startsWith(RCON_PROOF_PREFIX)))) {
             const token = tag.slice(RCON_PROOF_PREFIX.length);
-            
+            const expected = await createToken({ host, password, secret: RCON_PROOF_SECRET });
+            if (token !== expected) {
+              throw new Error('Unable to verify token');
+            }
           } else {
             throw new Error('No token found in tags');
           }
         }
-        server.rconAuth(password);
+        await server.rconAuth(password);
       }
 
       return {

--- a/graphql-server/token.ts
+++ b/graphql-server/token.ts
@@ -1,0 +1,12 @@
+import { createHmac } from 'crypto';
+import { TokenData } from './defs';
+
+const hashAlgorithm = 'sha256';
+
+export async function createToken(data: TokenData): Promise<string> {
+  const hmac = createHmac(hashAlgorithm, data.secret);
+  hmac.update(data.host);
+  hmac.update(data.secret);
+  hmac.update(data.password);
+  return hmac.digest('base64');
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -8760,9 +8760,9 @@
       "dev": true
     },
     "steam-condenser": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/steam-condenser/-/steam-condenser-0.1.4.tgz",
-      "integrity": "sha512-cNTjFlFo76FNGfRXKbEkk1Fs+50xRk4TxhuqvTelyuvHZCkEGyr8LVKtt75kRzEEY8x5TTGCd2DoENF6YhO92Q==",
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/steam-condenser/-/steam-condenser-0.1.5.tgz",
+      "integrity": "sha512-onDv7cLDeCkUOhXyt+7eGH5r9n6cM+YCxZ7swiHl8anFkaagsTz7D5DEaeYYrFhELLCkUQna3Jf12+9d/5E9Fg==",
       "requires": {
         "bignum": "^0.13.1",
         "xmldoc": "^1.1.0"

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "dependencies": {
     "apollo-server": "^2.14.3",
     "graphql": "^15.1.0",
-    "steam-condenser": "^0.1.4"
+    "steam-condenser": "^0.1.5"
   },
   "devDependencies": {
     "@vue/cli": "^4.4.4",


### PR DESCRIPTION
Create HMAC from password, host and secret. Require server to put this value into sv_tags before attempting to authenticate.

This makes it impossible or very hard to attempt rcon authenticating to servers user doesn't own since they need both rcon password and secret srcds-ql secret.